### PR TITLE
Datasets with empty source are ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Changed
+- Datasets with empty source are ignored
+
 ## [0.1.1] 2016-09-13
 ### Changes
 - Enhanced CI support
@@ -8,4 +12,3 @@ All notable changes to this project will be documented in this file.
 ## [0.1.0] 2016-07-01
 ### First version
 - Data management API and daemons 
-

--- a/data-service/src/main/resources/dataservice/hdb.py
+++ b/data-service/src/main/resources/dataservice/hdb.py
@@ -141,8 +141,14 @@ class HDBDataStore(object):
         try:
             for root, dirs, _ in self.client.walk(repo_path, topdown=True, onerror=onerror):
                 for entry in dirs:
-                    if "source=" in entry:
-                        item = {DATASET.ID: re.sub('source=', '', entry),
+                    m_source = re.match('^source=(?P<source>.*)', entry)
+                    if m_source is None:
+                        continue
+                    elif m_source.group('source') == '':
+                        logging.warn('An empty source is present, this is not allowed. Something was wrong during ingestion')
+                        continue
+                    else:
+                        item = {DATASET.ID: m_source.group('source'),
                                 DATASET.POLICY: POLICY.SIZE,
                                 DATASET.PATH: os.path.join(root, entry), DATASET.MODE: 'keep'}
                         hdfs_dataset.append(item)


### PR DESCRIPTION
If the dataset is empty a warning is logged.
If the dataset directory does not match 'source=.*' it is ignored

PNDA-2312