### PR TITLE
PNDA-3427: Configure data-service with the webhdfs services.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ### Added:
 - PNDA-2445: Support for Hortonworks HDP
 
+### Fixed
+- PNDA-3427: Configure data-service with the webhdfs services.
+
 ## [0.2.0] 2017-01-20
 ### Changed
 - PNDA-2485: Pinned all python libraries to strict version numbers


### PR DESCRIPTION
In HDP the following setting is exposed by the rest API:
  fs.defaultFS = hdfs://HDFS-HA
and so can not be used to determine where the httpfs proxies are running.
In HDP the httpfs proxy is currently configured to run on all 4 managers
through salt but there is no information in the Hadoop REST API that
exposes these service locations.
So currently, the data-service will be configured with the WebHDFS
services when running in HDP mode.