### PR TITLE
PNDA-3127: Post ingress aggregation for Kafka datasets

### DIFF
--- a/hdfs-cleaner/src/main/resources/hdfs-cleaner.py
+++ b/hdfs-cleaner/src/main/resources/hdfs-cleaner.py
@@ -371,6 +371,19 @@ def main():
                           general_dirs_to_clean, NEG_SIZE)
     jobs.append(job_common_dirs)
 
+    # staging dataset to clean
+    staging_dataset_to_clean = properties['staging_dataset_to_clean']
+    if 'mode' in staging_dataset_to_clean.keys():
+	if staging_dataset_to_clean['mode'] == 'delete':
+	   cmd = delete_cmd
+	else:
+	   cmd = archive_cmd
+        age = staging_dataset_to_clean.get('age', 1)
+        staging_dataset_location = staging_dataset_to_clean['staging_dataset_location']
+        job_staging_dirs = JOB('clean_staging_dataset', hdfs, cleanup_on_age, cmd,
+                              staging_dataset_location, age)
+        jobs.append(job_staging_dirs)
+
     old_dirs_to_clean = properties['old_dirs_to_clean']
     for entry in old_dirs_to_clean:
         print entry['name']


### PR DESCRIPTION
1. Gobblin Compaction-

*******************
1.1. Brief
--Compaction strategy will be set at deployment level
--If compaction is enabled, datasets from pull job will be stored in a different directory - /user/pnda/PNDA_datasets/hourly_staging/
--Compaction strategy will apply to all the datasets (system wide)
--User at the time of deployment will be able to control following parameters w.r.t. compaction
---Enable/Disable compaction
---Level of compaction <Hourly(H), Daily(d), Monthly(M), Yearly(Y)>
---Archive or delete hourly_staging data

**Note: when the datasets would appear in master dataset (/user/pnda/PNDA_datasets/datasets) will depend on the level of compaction. For instance in case of hourly compaction  it will appear 
after a lag of 2 hours from the time it was pulled into staging directory, for daily compaction after a lag 1 day and so on.


1.2. At deployment level, using pnda-cli/pnda_env.yaml user can enable/disable compaction, defaults to disable.
Compaction properties will apply system wide and not per dataset. 

pnda-cli/pnda_env.yaml

dataset_compaction:
    compaction: "YES"
    level: H
    retention_mode: delete

1.2.1 Parameters-

compaction - To enable/disable compaction: "YES"/"NO"
level - To set compaction strategy: H - hourly, d - daily, M - monthly, Y - yearly
retention_mode - Manage staging data once compaction is complete on it: archive/delete

1.3. Compaction behavior
Case: 1.3.1. compaction is set to "NO"
--No compaction will be performed 
--Pull job will submit data to /user/pnda/PNDA_datasets/datasets/

Case: 1.3.2. compaction is "YES"
--compaction will be performed 
--Pull job will submit data to /user/pnda/PNDA_datasets/staging/
--compaction job will run on data in staging directory. compacted data will be stored in /user/pnda/PNDA_datasets/datasets/

Case: 1.3.2.1. level: H
--Compaction job will run every hour
--Will compact data not older than 1 day and which is not being generated in past 1 hour
--Staging data older than 2 days will be deleted/archived

Case: 1.3.2.1.2. level: d
--Compaction job will run once a day
--Will compact data not older than 1 day and which is not being generated in past 1 hour
--Staging data older than 2 days will be deleted/archived

Case: 1.3.2.1.3. level: M
--Compaction job will run once a month
--Will compact data not older than 1 month and which is not being generated in past 1 hour
--Staging data older than 32 days will be deleted/archived

Case: 1.3.2.1.4. level: Y
--Compaction job will run once a year
--Will compact data not older than 1 year and which is not being generated in past 1 hour
--Staging data older than 367 days will be deleted/archived


**********************
2. hourly_staging data clean up
--Will be performed by hdfs-cleaner based on parameter set in properties.json.
--properties.json will be updated based on level and retention_mode provided in pnda.sls


**********************
3. Cron configuration

Case: 3.1. level: H
0 * * * * 	

Case: 3.2. level: d
0 1 * * * 	

Case: 3.3. level: M
0 1 1 * * 	

Case: 3.4. level: Y
0 1 1 1 *  

**********************
PNDA-3127 has dependency upon PNDA-3133