### PR TITLE
PNDA-4426: Dataset service is missing a log level config setting

### DIFF
--- a/data-service/src/main/resources/apiserver.py
+++ b/data-service/src/main/resources/apiserver.py
@@ -17,6 +17,7 @@
 import logging
 import signal
 import socket
+import sys
 
 import tornado.httpserver
 import tornado.ioloop
@@ -29,7 +30,7 @@ import dataservice
 from dataservice import HDBDataStore
 from endpoint import Platform
 
-
+options.logging = None
 APISERVER = None
 
 def sig_handler(sig, frame):
@@ -61,14 +62,23 @@ def main():
     # pylint: disable=global-statement
     global APISERVER
     config.define_options()
+    err_msg = ''
     # Attempt to load config from config file
     try:
         parse_config_file("server.conf")
     except IOError:
-        errmsg = ("{} doesn't exist or couldn't be opened. Using defaults."
-                  .format(options.conf_file_path))
-        logging.warn(errmsg)
+        err_msg = ("{} doesn't exist or couldn't be opened. Using defaults."
+                   .format(options.conf_file_path))
+
+    logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s',
+                        level=logging.getLevelName(options.log_level),
+                        filename=options.log_file_prefix,
+                        stream=sys.stderr)
+
     logging.info(options.as_dict())
+    if err_msg:
+        logging.error(err_msg)
+
     platform = Platform.factory(options.hadoop_distro)
     endpoints = platform.discover(options)
     if not endpoints:

--- a/data-service/src/main/resources/config.py
+++ b/data-service/src/main/resources/config.py
@@ -42,3 +42,5 @@ def define_options():
     define("cm_host", default='localhost', help="The cluster manager interface", type=str)
     define("cm_user", default='admin', help="The user name for cluster manager", type=str)
     define("cm_pass", default='admin', help="The password for cluster manager", type=str)
+    define("log_level", default='INFO', help="The log level setting for logging", type=str)
+    define("log_file_prefix", default='dataservice.log', help="The log file for logging", type=str)

--- a/data-service/src/main/resources/server.conf
+++ b/data-service/src/main/resources/server.conf
@@ -1,5 +1,5 @@
 ports = [7000, 7001]
-bind_address = '0.0.0.0'
+bind_address = "0.0.0.0"
 sync_period = 5000
 datasets_table = "platform_datasets"
 data_repo = "/user/PNDA/datasets"
@@ -7,5 +7,5 @@ hadoop_distro = "hdp"
 cm_host = "1.2.3.4"
 cm_user = "admin"
 cm_pass = "admin"
-log_file_prefix="apiserver.log"
-logging = 'debug'
+log_file_prefix = "dataservice.log"
+log_level = "INFO"


### PR DESCRIPTION
# Problem Statement:
PNDA-4426: Dataset service is missing a log level config setting

Dependency PR - https://github.com/pndaproject/platform-salt/pull/548

# Changes:
Added the change to configure the application logging level from the configuration file ( server.conf ).
So, changing the log level in conf file and restart the service will be sufficient to change the logging.

# Test details
RHEL - PICO - CDH & HDP