### PR TITLE
PNDA-4878: HDFS-cleaner fails to delete the last file that should have been deleted.

### DIFF
--- a/hdfs-cleaner/src/main/resources/hdfs-cleaner.py
+++ b/hdfs-cleaner/src/main/resources/hdfs-cleaner.py
@@ -196,11 +196,16 @@ def cleanup_on_size(hdfs, cmd, clean_path, size_threshold):
                                                    onerror=error):
                     logging.info("Root:{%s}->Dirs:{%s}->Files:{%s}", root, dirs, files)
                     for item in files:
-                        abspath = path.join(root, item)
-                        space_consumed -= extract_size(hdfs, abspath)
+                        
                         if space_consumed <= size_threshold:
                             break
+
+                        # Read the file-size from HDFS, remove file and update the space_consumed
+                        abspath = path.join(root, item)
+                        file_size = extract_size(hdfs, abspath)
                         cmd(abspath)
+                        space_consumed -= file_size
+
                     clean_empty_dirs(hdfs, root, dirs)
         except HdfsFileNotFoundException as hdfs_file_not_found_exception:
             logging.warn("{%s}", hdfs_file_not_found_exception.message)


### PR DESCRIPTION
# Problem Statement:
PNDA-4878: HDFS-cleaner fails to delete the last file that should have been deleted.

# Changes:
Modified the cleanup_on_size function to delete the last file that should be deleted based on size rule policy.
Space consumed by HDFS directory should be updated after the conditional check for size threshold.

# Test details
RHEL - PICO - HDP
CENTOS - PICO - HDP