### PR TITLE
Added {{data_repo}}/topics folder to dataset tracking location

### DIFF
--- a/data-service/src/main/resources/dataservice/hdb.py
+++ b/data-service/src/main/resources/dataservice/hdb.py
@@ -161,6 +161,13 @@ class HDBDataStore(object):
                                 DATASET.PATH: os.path.join(root, entry), DATASET.MODE: 'keep'}
                         hdfs_dataset.append(item)
                 break
+            for root, dirs, _ in self.client.walk(repo_path + '/topics', topdown=True, onerror=onerror):
+                for entry in dirs:
+                    item = {DATASET.ID: entry,
+                                DATASET.POLICY: POLICY.SIZE,
+                                DATASET.PATH: os.path.join(root, entry), DATASET.MODE: 'keep'}
+                    hdfs_dataset.append(item)
+                break
         except HdfsException as exception:
             logging.warn("Error in walking HDFS File system %s", str(exception))
         return hdfs_dataset


### PR DESCRIPTION
We don't have an easy way to configure kafka-connect-hdfs-connector to sink kafka messages to {{data_repo}}/topic={{topic_name}}/ folder.  

We use kafka-connect-hdfs-connector to sink kafka messages to {{data_repo}}/topics/{{topic_name}}/ folder.  

data-service is updated to also search datasets in {{data_repo}}/topics/{{topic_name}} folder.